### PR TITLE
Migrate SN3 configs to wireguard_sn3.yaml

### DIFF
--- a/ansible/wireguard_sn3.yaml
+++ b/ansible/wireguard_sn3.yaml
@@ -13,7 +13,7 @@ wireguard_configs:
     # For NN135 RobJ (SN3 migration)
   - NAME: nn135
     PORT: 51900
-    PEER_PUBLIC_KEY: sD3bVQglZfq2j82or48q+i0R0KdszUPZRkcz4rVqAk8=
+    PEER_PUBLIC_KEY: V/wrXElkbVD13EJEJ6MfiBPyNH8ArBftbReH2NeIfkg=
     INTERFACE_ADDRESS: "10.70.250.125/30"
     NEIGHBORS: "10.70.250.126"
     TX_LENGTH: 1366

--- a/ansible/wireguard_sn3.yaml
+++ b/ansible/wireguard_sn3.yaml
@@ -1,4 +1,6 @@
 wireguard_configs:
+    ### Remote Hubs
+
     # For the super awesome remote hub NN592
   - NAME: nn592
     PORT: 51821
@@ -7,6 +9,116 @@ wireguard_configs:
     NEIGHBORS: "10.70.250.122"
     TX_LENGTH: 1420
     COST: 99
+
+    # For NN135 RobJ (SN3 migration)
+  - NAME: nn135
+    PORT: 51900
+    PEER_PUBLIC_KEY: sD3bVQglZfq2j82or48q+i0R0KdszUPZRkcz4rVqAk8=
+    INTERFACE_ADDRESS: "10.70.250.125/30"
+    NEIGHBORS: "10.70.250.126"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN136 AndyB Amazon VPC (SN3 migration)
+  - NAME: nn136
+    PORT: 51901
+    PEER_PUBLIC_KEY: BiII3RZxHQoYeWaeNrI0HVJBze1oO+9bcoWO59DWJlw=
+    INTERFACE_ADDRESS: "10.70.250.129/30"
+    NEIGHBORS: "10.70.250.130"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN1417 Soft Surplus/Hex House (SN3 migration)
+  - NAME: nn1417
+    PORT: 51902
+    PEER_PUBLIC_KEY: hK3Vpdos7sMIWhOMqOvWvBNLrKbyw7pEfDdOI1wobRA=
+    INTERFACE_ADDRESS: "10.70.250.133/30"
+    NEIGHBORS: "10.70.250.134"
+    TX_LENGTH: 1420
+    COST: 99
+
+    # For NN148 Harlem Kiosk (SN3 migration)
+  - NAME: nn148
+    PORT: 51903
+    PEER_PUBLIC_KEY: Qpx9x8eQ0/M3pKo5MQTA1dg0wFKOjo8kNh0iJxeiZ1U=
+    INTERFACE_ADDRESS: "10.70.250.137/30"
+    NEIGHBORS: "10.70.250.138"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN2299 Lily House (SN3 migration)
+  - NAME: nn2299
+    PORT: 51904
+    PEER_PUBLIC_KEY: o6xGrijkBrzhPNdDAiESpTk0Mjn68ASpQJH+0dHtJRA=
+    INTERFACE_ADDRESS: "10.70.250.141/30"
+    NEIGHBORS: "10.70.250.142"
+    TX_LENGTH: 1344
+    COST: 99
+
+    # For NN317 Temkin (SN3 migration)
+  - NAME: nn317
+    PORT: 51905
+    PEER_PUBLIC_KEY: WCJap7m+hhUI41O+2v3iI9UiFz5hXpRrCcIi6vUHYHU=
+    INTERFACE_ADDRESS: "10.70.250.145/30"
+    NEIGHBORS: "10.70.250.146"
+    TX_LENGTH: 1420
+    COST: 99
+
+    # For NN329 Simona (SN3 migration)
+  - NAME: nn329
+    PORT: 51906
+    PEER_PUBLIC_KEY: BwGzJInFuBR4sQI8eUk5TH5ZZvDI952abbHoEyXLcRc=
+    INTERFACE_ADDRESS: "10.70.250.149/30"
+    NEIGHBORS: "10.70.250.150"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN383 Piotr (SN3 migration)
+  - NAME: nn383
+    PORT: 51907
+    PEER_PUBLIC_KEY: wqq0bzKjsMAfRWEBdqAu/AG9IqNyvBziElz/AbsVzh4=
+    INTERFACE_ADDRESS: "10.70.250.153/30"
+    NEIGHBORS: "10.70.250.154"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN640 YAYB (SN3 migration)
+  - NAME: nn640
+    PORT: 51908
+    PEER_PUBLIC_KEY: MK8l7PMsQ/+Jz8Ul56BJLxrubj08f3jscKzMfVfRZQ0=
+    INTERFACE_ADDRESS: "10.70.250.157/30"
+    NEIGHBORS: "10.70.250.158"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For NN666 JohnB Home (SN3 migration)
+  - NAME: nn666
+    PORT: 51909
+    PEER_PUBLIC_KEY: JOHnBoxVAAH4JcL0QZbKYyuXP5WQzeSU3UIwXlRuzhA=
+    INTERFACE_ADDRESS: "10.70.250.161/30"
+    NEIGHBORS: "10.70.250.162"
+    TX_LENGTH: 1344
+    COST: 99
+
+    # For NN777 MattB Pine Plains (SN3 migration)
+  - NAME: nn777
+    PORT: 51910
+    PEER_PUBLIC_KEY: wUm8/urU56aHwE8I2voR4Pm/Y0rIJ2bD70wo+X//yX8=
+    INTERFACE_ADDRESS: "10.70.250.165/30"
+    NEIGHBORS: "10.70.250.166"
+    TX_LENGTH: 1366
+    COST: 99
+
+    # For Andrew Dickinson Amazon VPC (SN3 migration)
+  - NAME: andrewvpc
+    PORT: 51911
+    PEER_PUBLIC_KEY: 2uMY2He1KCRjnsXnKU4KVD6dfCXzUUxly117aXsZ3kc=
+    INTERFACE_ADDRESS: "10.70.250.169/30"
+    NEIGHBORS: "10.70.250.170"
+    TX_LENGTH: 1366
+    COST: 99
+
+    ### Road Warriors
 
     # For Daniel Heredia
   - NAME: danielheredia


### PR DESCRIPTION
active clients from nycmesh-713-vpn1:

wg135.conf (active)
wg136.conf (active)
wg1417.conf (active)
wg148.conf (active)
wg2299.conf (active)
wg317.conf (active)
wg329.conf (active)
wg383.conf (active)
wg640.conf (active)
wg666.conf (active)
wg692.conf (inactive? 28 days)
wg777.conf (active)
wg8201.conf (active)
wg8531.conf (active)
wgandrew.conf (active)