### PR TITLE
Update wireguard_sn10.yaml

### DIFF
--- a/ansible/wireguard_sn10.yaml
+++ b/ansible/wireguard_sn10.yaml
@@ -27,7 +27,7 @@ wireguard_configs:
     INTERFACE_ADDRESS: "10.70.247.129/30"
     NEIGHBORS: "10.70.247.130"
     TX_LENGTH: 1420
-    COST: 98
+    COST: 50
 
 ### Road Warriors
 


### PR DESCRIPTION
SN3 has a shorter path to exit, need to lower this to prefer SN10