### PR TITLE
add netfilter rules to allow for two-way BFD negotiation

### DIFF
--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -20,6 +20,11 @@
 -A INPUT -s 10.0.0.0/8 -d 224.0.0.5 --protocol 89 -j ACCEPT
 -A INPUT -s 10.0.0.0/8 -d 224.0.0.6 --protocol 89 -j ACCEPT
 
+# Allow incoming BFD traffic
+-A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 3784 -j ACCEPT
+-A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 3785 -j ACCEPT
+-A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 4784 -j ACCEPT
+
 {% for wg_config in wireguard_configs %}
 -A INPUT -p udp -m state --state NEW --dport {{ wg_config.PORT }} -j ACCEPT
 {% endfor %}


### PR DESCRIPTION
@james-otten - forgot to add the required firewall rules to allow two-way sync for bfd over the mesh. thanks for all of your help with this!