### PR TITLE
Add overlap test

### DIFF
--- a/ansible/tests.yaml
+++ b/ansible/tests.yaml
@@ -58,6 +58,14 @@
             msg: "INTERFACE_ADDRESS should be in the allocated space"
           when: (wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | ansible.utils.reduce_on_network(expected_range) | list | length | string) != wg_config_len.msg
 
+        - name: INTERFACE_ADDRESS ranges should not overlap
+          ansible.builtin.fail:
+            msg: "Overlap in INTERFACE_ADDRESS: {{ item.0 }},{{ item.1 }} - {{ (wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | list)[item[0] | int],(wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | list)[item[1] | int] }}"
+          with_nested:
+            - "{{ range(1, (wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | length)) | list }}"
+            - "{{ range(1, (wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | length)) | list }}"
+          when: item[0] != item[1] and ((wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | list)[item[0] | int] | ansible.utils.network_in_usable((wireguard_configs | map(attribute='INTERFACE_ADDRESS', default=expected_default) | list)[item[1] | int]))
+
     - name: NEIGHBORS property
       block:
         - name: NEIGHBORS should be an IP


### PR DESCRIPTION
The test will catch things like:

```
failed: [127.0.0.1] (item=[14, 15]) => {"ansible_loop_var": "item", "changed": false, "item": [14, 15], "msg": "Overlap in INTERFACE_ADDRESS: 14,15 - ('10.70.250.177/30', '10.70.250.178/32')"}
```