### PR TITLE
Add invalid property test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vpn
 vpn.pub
 vpn_ed25519
 vpn_ed25519.pub
+settings.json

--- a/ansible/tests.yaml
+++ b/ansible/tests.yaml
@@ -1,5 +1,19 @@
 - name: Wireguard config tests
   hosts: 127.0.0.1
+  vars:
+    VALID_PROPERTY_NAMES:
+      - "NAME"
+      - "PORT"
+      - "PEER_PUBLIC_KEY"
+      - "INTERFACE_ADDRESS"
+      - "PEER_ALLOWED_IPS"
+      - "PEER_PERSISTENT_KEEPALIVE"
+      - "BFD_ENABLE"
+      - "BFD_INTERVAL"
+      - "BFD_MULTIPLIER"
+      - "NEIGHBORS"
+      - "TX_LENGTH"
+      - "COST"
   tasks:
     - name: Load variables
       ansible.builtin.include_vars:
@@ -9,6 +23,12 @@
       ansible.builtin.debug:
         msg: "{{ wireguard_configs | list | length }}"
       register: wg_config_len
+
+    - name: Check property names
+      ansible.builtin.fail:
+        msg: Unexpected property in config - {{ item.keys() | difference(VALID_PROPERTY_NAMES) }}
+      with_list: "{{ wireguard_configs | list }}"
+      when: item.keys() | difference(VALID_PROPERTY_NAMES)
 
     - name: NAME property
       block:

--- a/ansible/tests.yaml
+++ b/ansible/tests.yaml
@@ -1,7 +1,7 @@
 - name: Wireguard config tests
   hosts: 127.0.0.1
   vars:
-    VALID_PROPERTY_NAMES:
+    valid_property_names:
       - "NAME"
       - "PORT"
       - "PEER_PUBLIC_KEY"
@@ -26,9 +26,9 @@
 
     - name: Check property names
       ansible.builtin.fail:
-        msg: Unexpected property in config - {{ item.keys() | difference(VALID_PROPERTY_NAMES) }}
+        msg: Unexpected property in config - {{ item.keys() | difference(valid_property_names) }}
       with_list: "{{ wireguard_configs | list }}"
-      when: item.keys() | difference(VALID_PROPERTY_NAMES)
+      when: item.keys() | difference(valid_property_names)
 
     - name: NAME property
       block:


### PR DESCRIPTION
Detect invalid config property names:

```
  - NAME: nn592
    PO_oh_no_RT: 51821
    PEER_PUBLIC_KEY: sD3bVQglZfq2j82or48q+i0R0KdszUPZRkcz4rVqAk8=
    INTERFACE_ADDRESS: "10.70.250.121/30"
    NEIGHBORS: "10.70.250.122"
    TX_LENGTH: 1420
    COST: 99
```

-> 

```
 "msg": "Unexpected property in config - ['PO_oh_no_RT']"}
```