### PR TITLE
Add REJECT rule for internal VPN connections

### DIFF
--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -25,7 +25,9 @@
 -A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 3785 -j ACCEPT
 -A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 4784 -j ACCEPT
 
--A INPUT -s 10.0.0.0/8 -p udp -m udp --dport 33434:33474 -j REJECT --reject-with icmp-port-unreachable
+# Disallow establishing VPN connections from intra-mesh addresses. 
+# VPNs are supposed to be for external connections and this prevents the ouroboros condition
+-A INPUT -s 10.0.0.0/8 -p udp -m udp --dport 51800:53000 -j REJECT --reject-with icmp-port-unreachable
 
 {% for wg_config in wireguard_configs %}
 -A INPUT -p udp -m state --state NEW --dport {{ wg_config.PORT }} -j ACCEPT

--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -25,6 +25,8 @@
 -A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 3785 -j ACCEPT
 -A INPUT -s 10.0.0.0/8 -p udp -m state --state NEW -m udp --dport 4784 -j ACCEPT
 
+-A INPUT -s 10.0.0.0/8 -p udp -m udp --dport 33434:33474 -j REJECT --reject-with icmp-port-unreachable
+
 {% for wg_config in wireguard_configs %}
 -A INPUT -p udp -m state --state NEW --dport {{ wg_config.PORT }} -j ACCEPT
 {% endfor %}


### PR DESCRIPTION
A common client-side VPN configuration mistake is to forget to add a static route for the VPN connection. If the VPN connection is non-primary, this will be virtually undetectable, as the OSPF handshake completes successfully via the inside of the mesh. Then, when the backup is put into service, the VPN tunnel does an ouroboros as it tries to send encapsulated packets over the tunnel to reach the VPN server, and everything fails catastrophically

For this reason, it's important that we don't allow VPN connections to be established from 10.x source addresses. This makes these "fake VPN connections" fail to handshake and therefore the OSPF neighbor-ship isn't established (something volunteers are much more likely to notice and correct). 

Rolling out this PR may "break" some OSPF links, but arguably if that happens they are already broken, and we are just letting people know :)  