### PR TITLE
Reduce CCNY SN10 cost to 15

### DIFF
--- a/ansible/wireguard_sn10.yaml
+++ b/ansible/wireguard_sn10.yaml
@@ -48,7 +48,7 @@ wireguard_configs:
     INTERFACE_ADDRESS: "10.70.247.137/30"
     NEIGHBORS: "10.70.247.138"
     TX_LENGTH: 1420
-    COST: 200
+    COST: 15
     BFD_ENABLE: true
     BFD_INTERVAL: 500ms
     BFD_MULTIPLIER: 10


### PR DESCRIPTION
Change Harlem to SN10 as primary, as a troubleshooting step for slow UDP speeds