### PR TITLE
Add a workflow to bounce unconnected interfaces

### DIFF
--- a/.github/workflows/bounce.yaml
+++ b/.github/workflows/bounce.yaml
@@ -1,0 +1,45 @@
+name: Bounce All Environments
+permissions: read-all
+
+on:
+  push:
+    branches: # CLEANUP
+      - james/bounce
+  workflow_dispatch:
+    branches:
+      - main
+
+jobs:
+  validations:
+    name: Run tests
+    uses: ./.github/workflows/pr.yaml
+
+  bounce_dev3:
+    name: Deploy dev3
+    uses: ./.github/workflows/bounce_environment.yaml
+    with:
+      environment: dev3
+      varfile: dev.yaml
+    secrets: inherit
+    needs: validations
+    #if: github.ref == 'refs/heads/main'
+
+  bounce_prod1:
+    name: Deploy prod1
+    uses: ./.github/workflows/bounce_environment.yaml
+    with:
+      environment: prod1
+      varfile: wireguard_sn3.yaml
+    secrets: inherit
+    needs: deploy_dev3
+    if: github.ref == 'refs/heads/main'
+
+  bounce_prod2:
+    name: Deploy prod2
+    uses: ./.github/workflows/bounce_environment.yaml
+    with:
+      environment: prod2
+      varfile: wireguard_sn10.yaml
+    secrets: inherit
+    needs: deploy_prod1
+    if: github.ref == 'refs/heads/main'

--- a/.github/workflows/bounce.yaml
+++ b/.github/workflows/bounce.yaml
@@ -2,9 +2,6 @@ name: Bounce All Environments
 permissions: read-all
 
 on:
-  push:
-    branches: # CLEANUP
-      - james/bounce
   workflow_dispatch:
     branches:
       - main
@@ -22,7 +19,7 @@ jobs:
       varfile: dev.yaml
     secrets: inherit
     needs: validations
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
   bounce_prod1:
     name: Deploy prod1

--- a/.github/workflows/bounce.yaml
+++ b/.github/workflows/bounce.yaml
@@ -31,7 +31,7 @@ jobs:
       environment: prod1
       varfile: wireguard_sn3.yaml
     secrets: inherit
-    needs: deploy_dev3
+    needs: bounce_dev3
     if: github.ref == 'refs/heads/main'
 
   bounce_prod2:
@@ -41,5 +41,5 @@ jobs:
       environment: prod2
       varfile: wireguard_sn10.yaml
     secrets: inherit
-    needs: deploy_prod1
+    needs: bounce_prod1
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/bounce_environment.yaml
+++ b/.github/workflows/bounce_environment.yaml
@@ -81,14 +81,14 @@ jobs:
           sudo ip link set up dev wg0
           rm privatekey
 
-      - name: Terraform Apply
-        run: |
-          terraform apply -auto-approve -input=false -var-file=${{ inputs.environment }}.tfvars
-        working-directory: ./terraform/
+      # - name: Terraform Apply
+      #   run: |
+      #     terraform apply -auto-approve -input=false -var-file=${{ inputs.environment }}.tfvars
+      #   working-directory: ./terraform/
 
       - name: Run playbook
         run: |
           mv "${{ inputs.varfile }}" wireguard.yaml
           export PATH="$HOME/.local/bin:$PATH"
-          ansible-playbook bounce_interfaces.yaml
+          ansible-playbook -i inventory.yaml bounce_interfaces.yaml
         working-directory: ./ansible/

--- a/.github/workflows/bounce_environment.yaml
+++ b/.github/workflows/bounce_environment.yaml
@@ -1,4 +1,4 @@
-name: Deploy VPN Server
+name: Bounce Environment
 permissions: read-all
 
 on:
@@ -28,7 +28,6 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # @v4
@@ -81,13 +80,9 @@ jobs:
           sudo ip link set up dev wg0
           rm privatekey
 
-      - name: Terraform Apply
-        run: |
-          terraform apply -auto-approve -input=false -var-file=${{ inputs.environment }}.tfvars
-        working-directory: ./terraform/
-
       - name: Run playbook
         run: |
           mv "${{ inputs.varfile }}" wireguard.yaml
-          export PATH="$HOME/.local/bin:$PATH" && ansible-playbook -i inventory.yaml vpn.yaml
+          export PATH="$HOME/.local/bin:$PATH"
+          ansible-playbook bounce_interfaces.yaml
         working-directory: ./ansible/

--- a/.github/workflows/bounce_environment.yaml
+++ b/.github/workflows/bounce_environment.yaml
@@ -81,6 +81,11 @@ jobs:
           sudo ip link set up dev wg0
           rm privatekey
 
+      - name: Terraform Apply
+        run: |
+          terraform apply -auto-approve -input=false -var-file=${{ inputs.environment }}.tfvars
+        working-directory: ./terraform/
+
       - name: Run playbook
         run: |
           mv "${{ inputs.varfile }}" wireguard.yaml

--- a/.github/workflows/bounce_environment.yaml
+++ b/.github/workflows/bounce_environment.yaml
@@ -81,11 +81,6 @@ jobs:
           sudo ip link set up dev wg0
           rm privatekey
 
-      # - name: Terraform Apply
-      #   run: |
-      #     terraform apply -auto-approve -input=false -var-file=${{ inputs.environment }}.tfvars
-      #   working-directory: ./terraform/
-
       - name: Run playbook
         run: |
           mv "${{ inputs.varfile }}" wireguard.yaml

--- a/.github/workflows/bounce_environment.yaml
+++ b/.github/workflows/bounce_environment.yaml
@@ -28,6 +28,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # @v4

--- a/ansible/.ansible-lint-ignore
+++ b/ansible/.ansible-lint-ignore
@@ -3,3 +3,5 @@ roles/vpn_mgt/tasks/system_interfaces.yaml no-changed-when
 roles/vpn_mgt/tasks/wg_config.yaml no-changed-when
 roles/vpn_mgt/tasks/wg_config.yaml yaml[line-length]
 tests.yaml yaml[line-length]
+bounce_interfaces.yaml no-changed-when
+bounce_interfaces.yaml yaml[line-length]

--- a/ansible/bounce_interfaces.yaml
+++ b/ansible/bounce_interfaces.yaml
@@ -13,7 +13,7 @@
             last_handshake="$(wg show wg{{ item.NAME }} latest-handshakes | awk '{print $2}')";
             difference=$(( $(date +%s) - last_handshake ));
             abs_difference=${difference#-};
-            if [ "$abs_difference" -le 300 ]; then;
+            if [ "$abs_difference" -le 300 ]; then
               echo "Recent handshake";
             else
               echo "Bounced interface";

--- a/ansible/bounce_interfaces.yaml
+++ b/ansible/bounce_interfaces.yaml
@@ -1,0 +1,23 @@
+- name: Bounce interfaces
+  hosts: vpn_mgt
+  become: true
+  vars_files:
+    - wireguard.yaml
+  tasks:
+    - name: Bounce inactive interfaces
+      ansible.builtin.command:
+        argv:
+          - /bin/bash
+          - -c
+          - |
+            last_handshake="$(wg show wg{{ item.NAME }} latest-handshakes | awk '{print $2}'";
+            difference=$(( $(date +%s) - last_handshake ));
+            abs_difference=${difference#-};
+            if [ "$abs_difference" -le 300 ]; then;
+              echo "Recent handshake";
+            else
+              echo "Bounced interface";
+              ifdown wg{{ item.NAME }};
+              ifup wg{{ item.NAME }};
+            fi;
+      loop: "{{ wireguard_configs }}"

--- a/ansible/bounce_interfaces.yaml
+++ b/ansible/bounce_interfaces.yaml
@@ -10,7 +10,7 @@
           - /bin/bash
           - -c
           - |
-            last_handshake="$(wg show wg{{ item.NAME }} latest-handshakes | awk '{print $2}'";
+            last_handshake="$(wg show wg{{ item.NAME }} latest-handshakes | awk '{print $2}')";
             difference=$(( $(date +%s) - last_handshake ));
             abs_difference=${difference#-};
             if [ "$abs_difference" -le 300 ]; then;


### PR DESCRIPTION
John has more details on a possible wireguard bug that can cause interfaces to hang in specific cases. To work around this, a new workflow is added which can be run manually that will bounce each interface that has not had a handshake in a specified time period (300 seconds).

After this is merged, it can be run by authorized users from https://github.com/nycmeshnet/vpn-infra/actions/workflows/bounce.yaml