### PR TITLE
7800 SN10 cost 30>50

### DIFF
--- a/ansible/wireguard_sn10.yaml
+++ b/ansible/wireguard_sn10.yaml
@@ -48,7 +48,7 @@ wireguard_configs:
     INTERFACE_ADDRESS: "10.70.247.137/30"
     NEIGHBORS: "10.70.247.138"
     TX_LENGTH: 1420
-    COST: 30
+    COST: 50
     BFD_ENABLE: true
     BFD_INTERVAL: 500ms
     BFD_MULTIPLIER: 10


### PR DESCRIPTION
SN10 VPN nodes have shorter path through 7800 wireguard. This increases the cost so everyone prefers the primary Belmont > Lily > Sugar Hill path, in-mesh.

Please don't merge immediately, need to enable in parallel with change on 10.69.78.100