### PR TITLE
Temporarily Roll back 10.0.0.0/8 VPN Block

### DIFF
--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -27,7 +27,7 @@
 
 # Disallow establishing VPN connections from intra-mesh addresses. 
 # VPNs are supposed to be for external connections and this prevents the ouroboros condition
--A INPUT -s 10.0.0.0/8 -p udp -m udp --dport 51800:53000 -j REJECT --reject-with icmp-port-unreachable
+#-A INPUT -s 10.0.0.0/8 -p udp -m udp --dport 51800:53000 -j REJECT --reject-with icmp-port-unreachable
 
 {% for wg_config in wireguard_configs %}
 -A INPUT -p udp -m state --state NEW --dport {{ wg_config.PORT }} -j ACCEPT


### PR DESCRIPTION
Checking to see if this netfilter rule is causing problems for NN177 when using WG SN3 via linknyc as my backup connection. 


please see thread on slack: https://nycmesh.slack.com/archives/C01G52U577X/p1754706896737429 thanks