### PR TITLE
Update netfilter.j2 - allow input/forwarding for SN3 public IP range

### DIFF
--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -46,6 +46,8 @@
 -A FORWARD -s 10.0.0.0/8 -j ACCEPT
 # Allow forwarding for SN3 public IP traffic
 -A FORWARD -s 199.170.132.0/24 -j ACCEPT
+# Allow forwarding for mesh private subnet traffic
+-A FORWARD -d 10.0.0.0/8 -j ACCEPT
 -A FORWARD -i eth0 -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -j DROP
 -A FORWARD -j ACCEPT
 

--- a/ansible/roles/vpn_mgt/templates/netfilter.j2
+++ b/ansible/roles/vpn_mgt/templates/netfilter.j2
@@ -16,6 +16,9 @@
 
 -A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
 
+# Allow SN3 public IP traffic
+-A INPUT -s 199.170.132.0/24 -j ACCEPT
+
 # Allow incoming OSPF traffic (protocol 89) on the specified multicast addresses
 -A INPUT -s 10.0.0.0/8 -d 224.0.0.5 --protocol 89 -j ACCEPT
 -A INPUT -s 10.0.0.0/8 -d 224.0.0.6 --protocol 89 -j ACCEPT
@@ -41,6 +44,8 @@
 -A FORWARD -d {{ WG_PRIVATE_RANGE }} -j ACCEPT
 
 -A FORWARD -s 10.0.0.0/8 -j ACCEPT
+# Allow forwarding for SN3 public IP traffic
+-A FORWARD -s 199.170.132.0/24 -j ACCEPT
 -A FORWARD -i eth0 -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -j DROP
 -A FORWARD -j ACCEPT
 


### PR DESCRIPTION
testing to see if this is the reason why NN177 cant pass traffic via WG VPN. this will identify if this is the issue and we can roll it back/change if needed.