### PR TITLE
Add Neel Laptop Wireguard configuration

### DIFF
--- a/ansible/wireguard_sn3.yaml
+++ b/ansible/wireguard_sn3.yaml
@@ -650,6 +650,12 @@ wireguard_configs:
     PEER_PUBLIC_KEY: rVaiRSz9/+1sHMKZyWKw1fBVH+CklkmE8Gq4MZhX2A8=
     INTERFACE_ADDRESS: "10.70.249.20/31"
 
+    # For neel's laptop
+  - NAME: neellaptop
+    PORT: 51992
+    PEER_PUBLIC_KEY: d+5wB8kH2bu+h15uo+HWlB74/HP+zN/KG47AWNI+cTM=
+    INTERFACE_ADDRESS: "10.70.249.22/31"
+
     # ADD NEW ROAD WARRIORS ABOVE THIS LINE
 
     ### Site-to-site only


### PR DESCRIPTION
I'd like access to the mesh via VPN, so I added a configuration for this via my private key.

The reason for this is because I (and my family) live in a brownstone and cannot get Wi-Fi signals from the OmniTik in my computer room.

While I *can* use WinBox, it's not an option outside of my desktop. My home network uses segmented VLANs for Wi-Fi and wired.