### PR TITLE
Add leonpi1 road warrior config (SN10)

### DIFF
--- a/ansible/wireguard_sn10.yaml
+++ b/ansible/wireguard_sn10.yaml
@@ -205,6 +205,12 @@ wireguard_configs:
     PEER_PUBLIC_KEY: IILzKvhJ6DJjRZlbk7fg0sAepeebs9fHgYZpge391Fg=
     INTERFACE_ADDRESS: "10.70.247.26/31"
 
+    # Leon (pi1 home server road warrior)
+  - NAME: leonpi1
+    PORT: 51993
+    PEER_PUBLIC_KEY: y1dVHGnhsH17Gd93iNGw55RdgVIRHrjwSqnRf2ilvDQ=
+    INTERFACE_ADDRESS: "10.70.247.28/31"
+
 
     ### Site-to-site
 


### PR DESCRIPTION
Adds a road-warrior WireGuard peer for my home server (pi1) on SN10.

| Key | Value |
| --- | --- |
| NAME | `leonpi1` |
| PORT | `51993` (unused across all SN configs) |
| PEER_PUBLIC_KEY | `y1dVHGnhsH17Gd93iNGw55RdgVIRHrjwSqnRf2ilvDQ=` |
| INTERFACE_ADDRESS | `10.70.247.28/31` (next free /31 in the SN10 range) |

Split-tunnel client (will only route mesh ranges). Checked port/address/name uniqueness against the existing SN10 + other SN configs before picking the slot. Thanks!