### PR TITLE
Fix port for SN3 wg config

### DIFF
--- a/ansible/wireguard_sn3.yaml
+++ b/ansible/wireguard_sn3.yaml
@@ -656,9 +656,9 @@ wireguard_configs:
     PEER_PUBLIC_KEY: d+5wB8kH2bu+h15uo+HWlB74/HP+zN/KG47AWNI+cTM=
     INTERFACE_ADDRESS: "10.70.249.22/31"
 
-    # For Tony Perz laptop
+    # For Tony Perez laptop
   - NAME: ynotperez
-    PORT: 51820
+    PORT: 51993
     PEER_PUBLIC_KEY: IHAthJq00MwuJogGxtxkF0hNHjmiv7Qt4Md21+JK/B8=
     INTERFACE_ADDRESS: "10.70.249.24/31"
 


### PR DESCRIPTION
Corrects the WireGuard configuration for the `ynotperez` peer on SN3:

- Fix the listen `PORT` from `51820` to `51993`.
- Fix a name typo in the comment (`Tony Perz` → `Tony Perez`).